### PR TITLE
More robust hash function

### DIFF
--- a/src/khash.h
+++ b/src/khash.h
@@ -159,7 +159,7 @@ typedef unsigned long long khint64_t;
 #endif
 #endif /* klib_unused */
 
-typedef khint32_t khint_t;
+typedef khint64_t khint_t;
 typedef khint_t khiter_t;
 
 #define __ac_isempty(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&2)
@@ -174,6 +174,10 @@ typedef khint_t khiter_t;
 
 #ifndef kroundup32
 #define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+#endif
+
+#ifndef kroundup64
+#define kroundup64(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, (x)|=(x)>>32, ++(x))
 #endif
 
 #ifndef kcalloc
@@ -246,7 +250,7 @@ static const double __ac_HASH_UPPER = 0.77;
 		khint32_t *new_flags = 0;										\
 		khint_t j = 1;													\
 		{																\
-			kroundup32(new_n_buckets); 									\
+			kroundup64(new_n_buckets); 									\
 			if (new_n_buckets < 4) new_n_buckets = 4;					\
 			if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0;	/* requested size is too small */ \
 			else { /* hash table size to be changed (shrink or expand); rehash */ \
@@ -382,7 +386,8 @@ static const double __ac_HASH_UPPER = 0.77;
   @param  key   The integer [khint64_t]
   @return       The hash value [khint_t]
  */
-#define kh_int64_hash_func(key) (khint32_t)((key)>>33^(key)^(key)<<11)
+//#define kh_int64_hash_func(key) (khint32_t)((key)>>33^(key)^(key)<<11)
+#define kh_int64_hash_func(key) (khint64_t)(__ac_Wang_hash(key))
 /*! @function
   @abstract     64-bit integer comparison function
  */

--- a/src/khash_utils.h
+++ b/src/khash_utils.h
@@ -40,7 +40,7 @@ struct DifferenceInPlaceData##variant {                                         
 };                                                                                                                  \
                                                                                                                     \
 /* Determine whether the canonical k-mer is present.*/                                                              \
-bool containsKMer(kh_S##variant##_t *kMers, kmer##type##_t kMer, int k, bool complements) {                         \
+inline bool containsKMer(kh_S##variant##_t *kMers, kmer##type##_t kMer, int k, bool complements) {                  \
     if (complements) kMer = CanonicalKMer(kMer, k);                                                                 \
     bool contains_key = kh_get_S##variant(kMers, kMer) != kh_end(kMers);                                            \
     if (MINIMUM_ABUNDANCE == 1) return contains_key;                                                                \

--- a/src/prophasm.h
+++ b/src/prophasm.h
@@ -48,36 +48,36 @@ void NextSimplitig(KHT *kMers, kmer_t begin, std::ostream& of,  int k, bool comp
     std::string initialKMer = NumberToKMer(begin, k);
     std::list<char> simplitig {initialKMer.begin(), initialKMer.end()};
     eraseKMer(kMers, last, k, complements);
-    // TODO: print the right simplitig part directly after constructing the left part.
     bool extendToRight = true;
     bool extendToLeft = true;
-    while (extendToRight || extendToLeft) {
-        if (extendToRight) {
-            auto [ext, next] = RightExtension(last, kMers, k, complements);
-            if (ext == kmer_t(-1)) {
-                // No right extension found.
-                extendToRight = false;
-            } else {
-                // Extend the simplitig to the right.
-                eraseKMer(kMers, next, k, complements);
-                simplitig.emplace_back(letters[ext]);
-                last = next;
-            }
+    while (extendToLeft) {
+        auto [ext, next] =  LeftExtension(first, kMers, k, complements);
+        if (ext == kmer_t(-1)) {
+            // No left extension found.
+            extendToLeft = false;
         } else {
-            auto [ext, next] =  LeftExtension(first, kMers, k, complements);
-            if (ext == kmer_t(-1)) {
-                // No left extension found.
-                extendToLeft = false;
-            } else {
-                // Extend the simplitig to the left.
-                eraseKMer(kMers, next, k, complements);
-                simplitig.emplace_front(letters[ext]);
-                first = next;
-            }
+            // Extend the simplitig to the left.
+            eraseKMer(kMers, next, k, complements);
+            simplitig.emplace_front(letters[ext]);
+            first = next;
         }
     }
     of << ">" << simplitigID << std::endl;
-    of << std::string(simplitig.begin(), simplitig.end()) << std::endl;
+    of << std::string(simplitig.begin(), simplitig.end());
+    simplitig.resize(0);
+    while (extendToRight) {
+        auto [ext, next] = RightExtension(last, kMers, k, complements);
+        if (ext == kmer_t(-1)) {
+            // No right extension found.
+            extendToRight = false;
+        } else {
+            // Extend the simplitig to the right.
+            eraseKMer(kMers, next, k, complements);
+            of << letters[ext];
+            last = next;
+        }
+    }
+    of << std::endl;
 }
 
 

--- a/src/prophasm.h
+++ b/src/prophasm.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <algorithm>
 #include <fstream>
+#include <stack>
 
 #include "kmers.h"
 #include "khash_utils.h"
@@ -46,7 +47,10 @@ void NextSimplitig(KHT *kMers, kmer_t begin, std::ostream& of,  int k, bool comp
      // Maintain the first and last k-mer in the simplitig.
     kmer_t last = begin, first = begin;
     std::string initialKMer = NumberToKMer(begin, k);
-    std::list<char> simplitig {initialKMer.begin(), initialKMer.end()};
+    std::stack<char> simplitig {};
+    for (int i = k - 1; i >= 0; --i) {
+        simplitig.push(initialKMer[i]);
+    }
     eraseKMer(kMers, last, k, complements);
     bool extendToRight = true;
     bool extendToLeft = true;
@@ -58,13 +62,15 @@ void NextSimplitig(KHT *kMers, kmer_t begin, std::ostream& of,  int k, bool comp
         } else {
             // Extend the simplitig to the left.
             eraseKMer(kMers, next, k, complements);
-            simplitig.emplace_front(letters[ext]);
+            simplitig.push(letters[ext]);
             first = next;
         }
     }
     of << ">" << simplitigID << std::endl;
-    of << std::string(simplitig.begin(), simplitig.end());
-    simplitig.resize(0);
+    while (!simplitig.empty()) {
+        of << simplitig.top();
+        simplitig.pop();
+    }
     while (extendToRight) {
         auto [ext, next] = RightExtension(last, kMers, k, complements);
         if (ext == kmer_t(-1)) {


### PR DESCRIPTION
1 -- Using Wang-hash instead of the default one.

This should resolve the issue with k=18 as now k=18 is as fast as k=31 on my computer (the difference before was at my PC 1.3 times instead of 2x but anyway it should be resolved) -- the issue was probably due to hash collisions.

2 -- Using 64 bits in khash

This enables ProphAsm2 to scale for very large datasets.


Both combined have a slowdown about 5% for values where there were no hash collisions.